### PR TITLE
Add Inflatable Sewing System addon

### DIFF
--- a/inflatable_sewing_system/__init__.py
+++ b/inflatable_sewing_system/__init__.py
@@ -1,0 +1,40 @@
+bl_info = {
+    "name": "Inflatable Sewing System",
+    "author": "Codex",
+    "version": (1, 0, 0),
+    "blender": (4, 0, 0),
+    "location": "View3D > Sidebar > Inflatable",
+    "description": "Tools for generating and exporting inflatable sewing patterns",
+    "category": "Mesh",
+}
+
+import importlib
+from . import panel_ui, pattern_generator, cloth_simulation
+from . import dxf_svg_export, jpg_preview_export
+from . import json_csv_export, plt_export_operator
+
+modules = [
+    panel_ui,
+    pattern_generator,
+    cloth_simulation,
+    dxf_svg_export,
+    jpg_preview_export,
+    json_csv_export,
+    plt_export_operator,
+]
+
+
+def register():
+    for module in modules:
+        importlib.reload(module)
+        if hasattr(module, "register"):
+            module.register()
+
+
+def unregister():
+    for module in modules:
+        if hasattr(module, "unregister"):
+            module.unregister()
+
+if __name__ == "__main__":
+    register()

--- a/inflatable_sewing_system/cloth_simulation.py
+++ b/inflatable_sewing_system/cloth_simulation.py
@@ -1,0 +1,32 @@
+import bpy
+
+class RunClothSimOperator(bpy.types.Operator):
+    bl_idname = "inflatable.run_cloth_sim"
+    bl_label = "Run Cloth Simulation"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        obj = context.active_object
+        if not obj or obj.type != 'MESH':
+            self.report({'ERROR'}, 'Active object must be a mesh')
+            return {'CANCELLED'}
+
+        if 'Cloth' not in obj.modifiers:
+            mod = obj.modifiers.new(name='Cloth', type='CLOTH')
+            cloth = mod.settings
+            cloth.use_sewing_springs = True
+            cloth.sewing_force_max = 10
+        else:
+            mod = obj.modifiers['Cloth']
+
+        bpy.ops.object.modifier_apply(modifier=mod.name)
+        self.report({'INFO'}, 'Cloth simulation applied')
+        return {'FINISHED'}
+
+
+def register():
+    bpy.utils.register_class(RunClothSimOperator)
+
+
+def unregister():
+    bpy.utils.unregister_class(RunClothSimOperator)

--- a/inflatable_sewing_system/dxf_svg_export.py
+++ b/inflatable_sewing_system/dxf_svg_export.py
@@ -1,0 +1,65 @@
+import bpy
+import os
+
+class ExportPatternOperator(bpy.types.Operator):
+    bl_idname = "inflatable.export_pattern"
+    bl_label = "Export Pattern"
+
+    def execute(self, context):
+        props = context.scene.inflatable_props
+        obj = context.active_object
+        if not obj or obj.type != 'MESH':
+            self.report({'ERROR'}, 'Active object must be a mesh')
+            return {'CANCELLED'}
+
+        filepath = bpy.path.abspath("//pattern")
+        if props.export_format == 'SVG':
+            filepath += '.svg'
+            export_svg(obj, filepath)
+        elif props.export_format == 'DXF':
+            filepath += '.dxf'
+            export_dxf(obj, filepath)
+        elif props.export_format == 'JPG':
+            from .jpg_preview_export import export_jpg
+            filepath += '.jpg'
+            export_jpg(obj, filepath)
+        elif props.export_format == 'PLT':
+            from .plt_export_operator import export_plt
+            filepath += '.plt'
+            export_plt(obj, filepath)
+        self.report({'INFO'}, f'Exported {filepath}')
+        return {'FINISHED'}
+
+
+def export_svg(obj, filepath):
+    verts = [obj.matrix_world @ v.co for v in obj.data.vertices]
+    with open(filepath, 'w') as f:
+        f.write('<svg xmlns="http://www.w3.org/2000/svg" version="1.1">\n')
+        for e in obj.data.edges:
+            v1 = verts[e.vertices[0]]
+            v2 = verts[e.vertices[1]]
+            f.write(
+                f'<line x1="{v1.x}" y1="{v1.y}" x2="{v2.x}" y2="{v2.y}" ' \
+                'stroke="black" />\n')
+        f.write('</svg>')
+
+
+def export_dxf(obj, filepath):
+    verts = [obj.matrix_world @ v.co for v in obj.data.vertices]
+    with open(filepath, 'w') as f:
+        f.write("0\nSECTION\n2\nENTITIES\n")
+        for e in obj.data.edges:
+            v1 = verts[e.vertices[0]]
+            v2 = verts[e.vertices[1]]
+            f.write("0\nLINE\n8\n0\n")
+            f.write(f"10\n{v1.x*10}\n20\n{v1.y*10}\n30\n0.0\n")
+            f.write(f"11\n{v2.x*10}\n21\n{v2.y*10}\n31\n0.0\n")
+        f.write("0\nENDSEC\n0\nEOF\n")
+
+
+def register():
+    bpy.utils.register_class(ExportPatternOperator)
+
+
+def unregister():
+    bpy.utils.unregister_class(ExportPatternOperator)

--- a/inflatable_sewing_system/jpg_preview_export.py
+++ b/inflatable_sewing_system/jpg_preview_export.py
@@ -1,0 +1,23 @@
+import bpy
+
+
+def export_jpg(obj, filepath):
+    uv = obj.data.uv_layers.active
+    if not uv:
+        return
+    bpy.ops.object.select_all(action='DESELECT')
+    obj.select_set(True)
+    bpy.ops.uv.export_layout(filepath=filepath, mode='PNG', size=(2048, 2048))
+    # Convert PNG to JPG using Blender image API
+    img = bpy.data.images.load(filepath)
+    img.filepath_raw = filepath
+    img.file_format = 'JPEG'
+    img.save()
+    bpy.data.images.remove(img)
+
+def register():
+    pass
+
+
+def unregister():
+    pass

--- a/inflatable_sewing_system/json_csv_export.py
+++ b/inflatable_sewing_system/json_csv_export.py
@@ -1,0 +1,29 @@
+import bpy
+import json
+import csv
+
+
+def export_json_csv(obj, json_path, csv_path):
+    data = []
+    for poly in obj.data.polygons:
+        poly_data = {
+            'id': poly.index,
+            'verts': [list(obj.data.vertices[v].co) for v in poly.vertices]
+        }
+        data.append(poly_data)
+
+    with open(json_path, 'w') as jf:
+        json.dump(data, jf, indent=2)
+
+    with open(csv_path, 'w', newline='') as cf:
+        writer = csv.writer(cf)
+        writer.writerow(['id', 'verts'])
+        for d in data:
+            writer.writerow([d['id'], d['verts']])
+
+def register():
+    pass
+
+
+def unregister():
+    pass

--- a/inflatable_sewing_system/panel_ui.py
+++ b/inflatable_sewing_system/panel_ui.py
@@ -1,0 +1,109 @@
+import bpy
+from bpy.props import (
+    FloatProperty,
+    BoolProperty,
+    FloatVectorProperty,
+    EnumProperty,
+)
+
+from . import pattern_generator, cloth_simulation
+from . import dxf_svg_export, jpg_preview_export
+from . import json_csv_export, plt_export_operator
+
+
+class InflatableProperties(bpy.types.PropertyGroup):
+    stitch_spacing: FloatProperty(
+        name="Stitch Spacing (mm)",
+        default=5.0,
+        min=0.1,
+    )
+    seam_allowance: FloatProperty(
+        name="Seam Allowance (mm)",
+        default=10.0,
+        min=0.0,
+    )
+    font_size: FloatProperty(
+        name="Font Size",
+        default=12.0,
+        min=1.0,
+    )
+    font_thickness: FloatProperty(
+        name="Font Thickness",
+        default=1.0,
+        min=0.1,
+    )
+    label_bg: FloatVectorProperty(
+        name="Label BG",
+        subtype='COLOR',
+        size=3,
+        min=0.0,
+        max=1.0,
+        default=(1.0, 1.0, 1.0),
+    )
+    export_format: EnumProperty(
+        name="Format",
+        items=[
+            ('SVG', 'SVG', ''),
+            ('DXF', 'DXF', ''),
+            ('JPG', 'JPG', ''),
+            ('PLT', 'PLT', ''),
+        ],
+        default='SVG'
+    )
+    show_seams: BoolProperty(name="Show Seams", default=True)
+    show_labels: BoolProperty(name="Show Labels", default=True)
+    show_cut: BoolProperty(name="Show Cut Lines", default=True)
+    manual_symmetry: BoolProperty(name="Manual Symmetry", default=False)
+
+
+class INFLATABLE_PT_main(bpy.types.Panel):
+    bl_label = "Inflatable Sewing"
+    bl_idname = "INFLATABLE_PT_main"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'Inflatable'
+
+    def draw(self, context):
+        layout = self.layout
+        props = context.scene.inflatable_props
+
+        layout.operator(pattern_generator.GeneratePatternOperator.bl_idname)
+        layout.operator(dxf_svg_export.ExportPatternOperator.bl_idname)
+        layout.operator(cloth_simulation.RunClothSimOperator.bl_idname)
+
+        layout.separator()
+        layout.prop(props, "stitch_spacing")
+        layout.prop(props, "seam_allowance")
+        layout.prop(props, "font_size")
+        layout.prop(props, "font_thickness")
+        layout.prop(props, "label_bg")
+        layout.prop(props, "export_format")
+        layout.prop(props, "show_seams")
+        layout.prop(props, "show_labels")
+        layout.prop(props, "show_cut")
+        layout.prop(props, "manual_symmetry")
+
+
+def register():
+    bpy.utils.register_class(InflatableProperties)
+    bpy.types.Scene.inflatable_props = bpy.props.PointerProperty(type=InflatableProperties)
+    bpy.utils.register_class(INFLATABLE_PT_main)
+
+    pattern_generator.register()
+    cloth_simulation.register()
+    dxf_svg_export.register()
+    jpg_preview_export.register()
+    json_csv_export.register()
+    plt_export_operator.register()
+
+
+def unregister():
+    plt_export_operator.unregister()
+    json_csv_export.unregister()
+    jpg_preview_export.unregister()
+    dxf_svg_export.unregister()
+    cloth_simulation.unregister()
+    pattern_generator.unregister()
+    bpy.utils.unregister_class(INFLATABLE_PT_main)
+    del bpy.types.Scene.inflatable_props
+    bpy.utils.unregister_class(InflatableProperties)

--- a/inflatable_sewing_system/pattern_generator.py
+++ b/inflatable_sewing_system/pattern_generator.py
@@ -1,0 +1,52 @@
+import bpy
+import bmesh
+
+class GeneratePatternOperator(bpy.types.Operator):
+    bl_idname = "inflatable.generate_pattern"
+    bl_label = "Generate 2D Pattern & Label Corners"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        obj = context.active_object
+        if not obj or obj.type != 'MESH':
+            self.report({'ERROR'}, 'Active object must be a mesh')
+            return {'CANCELLED'}
+
+        # Duplicate mesh so original is preserved
+        dup = obj.copy()
+        dup.data = obj.data.copy()
+        context.collection.objects.link(dup)
+
+        # Make sure each face is separated by splitting vertices
+        me = dup.data
+        bm = bmesh.new()
+        bm.from_mesh(me)
+        bmesh.ops.split_edges(bm, edges=bm.edges)
+        bm.to_mesh(me)
+        bm.free()
+
+        # Unwrap using seams
+        bpy.ops.object.select_all(action='DESELECT')
+        dup.select_set(True)
+        context.view_layer.objects.active = dup
+        bpy.ops.uv.smart_project(angle_limit=66)
+
+        # Label corners using text objects
+        for i, v in enumerate(dup.data.vertices):
+            txt = bpy.data.curves.new(f"label_{i}", 'FONT')
+            txt.body = f"A{i}"
+            txt_obj = bpy.data.objects.new(f"label_{i}", txt)
+            context.collection.objects.link(txt_obj)
+            txt_obj.location = dup.matrix_world @ v.co
+            txt_obj.parent = dup
+
+        self.report({'INFO'}, 'Pattern generated')
+        return {'FINISHED'}
+
+
+def register():
+    bpy.utils.register_class(GeneratePatternOperator)
+
+
+def unregister():
+    bpy.utils.unregister_class(GeneratePatternOperator)

--- a/inflatable_sewing_system/plt_export_operator.py
+++ b/inflatable_sewing_system/plt_export_operator.py
@@ -1,0 +1,19 @@
+import bpy
+
+
+def export_plt(obj, filepath):
+    verts = [obj.matrix_world @ v.co for v in obj.data.vertices]
+    with open(filepath, 'w') as f:
+        f.write('IN;')
+        for e in obj.data.edges:
+            v1 = verts[e.vertices[0]]
+            v2 = verts[e.vertices[1]]
+            f.write(f'PU{v1.x*10},{v1.y*10};PD{v2.x*10},{v2.y*10};')
+        f.write('IN;')
+
+def register():
+    pass
+
+
+def unregister():
+    pass


### PR DESCRIPTION
## Summary
- implement `Inflatable Sewing System` Blender addon modules
- register UI panel and operations for pattern generation, export and cloth simulation
- support SVG/DXF/JPG/PLT exporting and JSON/CSV data dump

## Testing
- `python3 -m py_compile inflatable_sewing_system/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684ff9f8c374832ab78b67fbae8333af